### PR TITLE
Fix: change auth requests from FormData to JSON on iframe sample UI

### DIFF
--- a/iframe/sample/index.html
+++ b/iframe/sample/index.html
@@ -447,20 +447,22 @@
 				return;
 			}
 
-			try {
-				const formData = new FormData();
-				formData.append("email", email);
-				formData.append("username", username);
-				formData.append("name", name);
-				formData.append("password", password);
-
-				const response = await fetch(
-					`${AUTH_SERVER}/api/auth/sign-up/email`,
-					{
-						method: "POST",
-						body: formData,
+		try {
+			const response = await fetch(
+				`${AUTH_SERVER}/api/auth/sign-up/email`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
 					},
-				);
+					body: JSON.stringify({
+						email: email,
+						username: username,
+						name: name,
+						password: password,
+					}),
+				},
+			);
 
 				const data = await response.json();
 
@@ -491,18 +493,20 @@
 				return;
 			}
 
-			try {
-				const formData = new FormData();
-				formData.append("username", username);
-				formData.append("password", password);
-
-				const response = await fetch(
-					`${AUTH_SERVER}/api/auth/sign-in/username`,
-					{
-						method: "POST",
-						body: formData,
+		try {
+			const response = await fetch(
+				`${AUTH_SERVER}/api/auth/sign-in/username`,
+				{
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
 					},
-				);
+					body: JSON.stringify({
+						username: username,
+						password: password,
+					}),
+				},
+			);
 
 				const data = await response.json();
 


### PR DESCRIPTION
Registration and login endpoints returned `UNSUPPORTED_MEDIA_TYPE` because the code sent multipart/form-data while BetterAuth expects application/json. This issue was found on Firefox.

Updated `register()` and `login()` in iframe/sample/index.html to send JSON with Content-Type: application/json instead of FormData.
<img width="1386" height="505" alt="Screenshot 2025-12-23 at 10 30 35" src="https://github.com/user-attachments/assets/9c6516c5-d9c7-41e3-8e33-a7a1a0705cf7" />

<img width="1386" height="505" alt="Screenshot 2025-12-23 at 10 35 01" src="https://github.com/user-attachments/assets/ae8755b6-b25f-4a64-9d9c-c9508e1e1091" />
