### PR TITLE
Fix documentation accuracy issues (must-fix)

### DIFF
--- a/auth_service/.env.example
+++ b/auth_service/.env.example
@@ -1,5 +1,5 @@
-DB_HOST="localhost
-DB_PORT="5432
-DB_NAME="authservice
-DB_USER="postgres
+DB_HOST="localhost"
+DB_PORT="5432"
+DB_NAME="authservice"
+DB_USER="postgres"
 DB_PASS="postgres"

--- a/docs/pages/components/hot_storage.mdx
+++ b/docs/pages/components/hot_storage.mdx
@@ -26,8 +26,29 @@ Users must specify the user ID, auth provider, and device ID when requesting sha
 through a [JWT](https://www.jwt.io/) token issued by the specified auth service.
 The auth service must match the one configured when creating the share.
 
-Hot shares are not encrypted with user entropy, so it is important to ensure that the database is secure and access is controlled.
-Follow [best practices for database security](https://www.cybertec-postgresql.com/en/postgresql-security-things-to-avoid-in-real-life/).
+Hot shares are not encrypted with user entropy. However, the sample implementation encrypts all shares at rest
+using AES-256-GCM before storing them in the database. This protects shares if the database is compromised.
+
+### At-Rest Encryption
+
+The sample hot storage encrypts every share with a server-side key before writing it to PostgreSQL
+and decrypts it on read. The encryption uses AES-256 in GCM (Galois/Counter Mode) with a random 96-bit nonce
+per share. The stored value is `base64(nonce || ciphertext || GCM tag)`.
+
+The encryption key is configured through the `SHARE_ENCRYPTION_KEY` environment variable, which must be
+exactly 64 hex characters (32 bytes). Generate one with:
+
+```shell
+openssl rand -hex 32
+```
+
+:::warning
+Keep `SHARE_ENCRYPTION_KEY` secret. If this key is lost, all stored shares become unrecoverable.
+If it is compromised, an attacker with database access can decrypt every share.
+:::
+
+Even with at-rest encryption, follow [best practices for database security](https://www.cybertec-postgresql.com/en/postgresql-security-things-to-avoid-in-real-life/)
+to ensure access is properly controlled.
 
 ## Specification
 

--- a/docs/pages/introduction/setup.mdx
+++ b/docs/pages/introduction/setup.mdx
@@ -27,7 +27,31 @@ To run them, use:
 make run
 ```
 
-The components can be configured through environment variables,
-check out the `env.example` and the `docker-compose.yml` files for a list of available variables.
+The components are configured through environment variables.
+The `docker-compose.yml` file at the repository root lists every variable with its default value.
+Service-specific defaults are in files such as `auth_service/.env.example`.
+
+## Required Environment Variables
+
+Two variables have no defaults and **must** be set before running `make run`:
+
+| Variable | Used by | Description |
+|---|---|---|
+| `JWT_SECRET` | Auth service | Secret used to sign and verify JWTs. Use a long, random string. |
+| `SHARE_ENCRYPTION_KEY` | Hot storage | AES-256 key for encrypting shares at rest. Must be exactly 64 hex characters (32 bytes). Generate with `openssl rand -hex 32`. |
+
+## Optional Environment Variables
+
+These variables have sensible defaults for local development but should be configured for production:
+
+| Variable | Default | Description |
+|---|---|---|
+| `ALLOWED_ORIGINS` | `http://localhost:7050,http://localhost:7051` | Comma-separated list of allowed CORS origins. Used by both the auth service and hot storage. |
+| `BETTER_AUTH_BASE_URL` | `http://localhost:7052` | Public base URL of the auth service. |
+| `POSTGRES_USER` | `postgres` | PostgreSQL superuser name. |
+| `POSTGRES_PASSWORD` | `postgres_password` | PostgreSQL superuser password. |
+
+Each service also accepts database connection variables (`DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS`, `DB_SSLMODE`)
+with defaults suitable for the Docker Compose setup. See `docker-compose.yml` for the full list.
 
 Once you have everything running, head over to the [Getting Started](/introduction/getting-started) guide.

--- a/docs/pages/security/recovery-methods.mdx
+++ b/docs/pages/security/recovery-methods.mdx
@@ -12,7 +12,7 @@ Each refers to how the recovery share is encrypted, and how the user can access 
 
 In password-based recovery, the recovery share is encrypted with a user-provided password.
 Recovery share encryption and decryption happen in the iFrame, making the user the sole owner of the entropy guarding the share.
-Check out the [**password-based signup**](/actions/signup#user-with-password-recovery) section for more details.
+Check out the [**password-based signup**](/actions/signup#password-recovery) section for more details.
 
 :::info[Encryption Details]
 When setting a recovery password, the iframe uses the open-source [@openfort-xyz/crypto-js](https://github.com/openfort-xyz/crypto-js)
@@ -58,7 +58,7 @@ over one of the other two shares, allows the entity to reconstruct the key.
 
 The raw encryption key travels over the network from the iFrame to the cold storage and can be intercepted.
 Mitigate this with proper network security measures.
-Check out the [**automatic recovery signup**](/actions/signup#user-with-automatic-recovery) section for more details.
+Check out the [**automatic recovery signup**](/actions/signup#automatic-recovery) section for more details.
 
 ### The 3 Key Shares vs The 2 Encryption Parts
 

--- a/docs/public/swagger/auth_service.yaml
+++ b/docs/public/swagger/auth_service.yaml
@@ -2,451 +2,303 @@ openapi: 3.0.0
 info:
   title: OpenSigner Auth Service API
   version: 1.0.0
+  description: |
+    The authentication service is built on [Better Auth](https://www.better-auth.com/)
+    and provides user registration, session management, JWT issuance, and origin validation.
 
-# Tag definitions for grouping
-# ===========================
+    All `/api/auth/*` endpoints are handled by Better Auth. The service also exposes
+    a JWKS endpoint, an origin-validation endpoint consumed by the iframe nginx proxy,
+    and a health check.
+
 tags:
-  - name: OAuth
-    description: Endpoints for OAuth authentication (Google, Twitter, Facebook, Discord, Epic Games, Line, Apple)
-  - name: Third-Party OAuth
-    description: Endpoints for third-party OAuth authentication (Accelbyte, Firebase, Lootlocker, Playfab, Supabase, Custom, OIDC)
-  - name: Basic Auth
-    description: Endpoints for basic authentication (email/password, wallet/SIWE)
+  - name: Authentication
+    description: Sign up, sign in, and sign out with email and password.
+  - name: Session
+    description: Session management and JWT token retrieval.
+  - name: JWKS
+    description: JSON Web Key Set endpoints for token verification.
+  - name: Origin Validation
+    description: Origin validation for the iframe nginx proxy.
+  - name: Health
+    description: Service health check.
 
-# =====================
-# OAuth Authentication
-# =====================
 paths:
-  /iam/v1/oauth/init:
+  # ==========================
+  # Authentication
+  # ==========================
+  /api/auth/sign-up/email:
     post:
-      summary: Initialize OAuth
-      tags: [OAuth]
+      summary: Sign up with email and password
+      tags: [Authentication]
+      description: |
+        Register a new user with email and password. With the username plugin enabled,
+        an optional `username` field is accepted (max 30 characters, `admin` is blocked).
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OAuthInitRequest"
+              $ref: "#/components/schemas/SignUpRequest"
       responses:
-        "201":
-          description: Success response
+        "200":
+          description: User created successfully
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OAuthResponse"
-        "401":
-          description: Api key is not valid
+                $ref: "#/components/schemas/SessionResponse"
 
-  /iam/v1/oauth/pool:
+  /api/auth/sign-in/email:
     post:
-      summary: Poll OAuth (polling)
-      tags: [OAuth]
+      summary: Sign in with email and password
+      tags: [Authentication]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignInRequest"
+      responses:
+        "200":
+          description: Sign-in successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionResponse"
+        "401":
+          description: Invalid credentials
+
+  /api/auth/sign-out:
+    post:
+      summary: Sign out and invalidate session
+      tags: [Authentication]
+      description: |
+        Invalidate the current session. Requires a session cookie or Bearer token.
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Signed out successfully
+
+  # ==========================
+  # Session Management
+  # ==========================
+  /api/auth/get-session:
+    get:
+      summary: Get the current session
+      tags: [Session]
+      description: |
+        Return the current user and session. Requires a session cookie or Bearer token.
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      responses:
+        "200":
+          description: Current session
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionResponse"
+        "401":
+          description: Not authenticated
+
+  /api/auth/token:
+    get:
+      summary: Get a JWT access token
+      tags: [Session]
+      description: |
+        Exchange the current session for a short-lived JWT access token.
+        Requires a session cookie or Bearer token.
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      responses:
+        "200":
+          description: JWT token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    description: JWT access token
+
+  # ==========================
+  # JWKS
+  # ==========================
+  /api/auth/jwks:
+    get:
+      summary: JSON Web Key Set
+      tags: [JWKS]
+      description: |
+        Return the public keys used to verify JWT tokens issued by the auth service.
+      responses:
+        "200":
+          description: JWKS response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSResponse"
+
+  /.well-known/jwks.json:
+    get:
+      summary: JWKS (well-known alias)
+      tags: [JWKS]
+      description: |
+        Alias for `/api/auth/jwks`. Used by the hot storage service to validate JWT tokens.
+      responses:
+        "200":
+          description: JWKS response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWKSResponse"
+
+  # ==========================
+  # Origin Validation
+  # ==========================
+  /v1/projects/validate-origin:
+    get:
+      summary: Validate a request origin
+      tags: [Origin Validation]
+      description: |
+        Used by the iframe nginx `auth_request` subrequest. Checks if the `X-Request-Origin`
+        header value is in the configured `ALLOWED_ORIGINS` list. Returns `X-Allowed-Origins`
+        response header on success for CSP `frame-ancestors`.
       parameters:
-        - in: query
-          name: key
+        - in: header
+          name: X-Request-Origin
           schema:
             type: string
-          required: true
+          required: false
+          description: The origin to validate. Defaults to `openfort.io` if not provided.
       responses:
         "200":
-          description: Success response
-          content:
-            application/json:
+          description: Origin is allowed
+          headers:
+            X-Allowed-Origins:
               schema:
-                $ref: "#/components/schemas/AuthResponse"
-        "401":
-          description: Api key is not valid
-
-  /iam/v1/oauth/login_id_token:
-    post:
-      summary: Login with ID Token (OAuth)
-      tags: [OAuth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LoginWithIdTokenRequest"
-      responses:
-        "200":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthResponse"
-        "401":
-          description: Unauthorized
-
-  /iam/v1/oauth/verify:
-    post:
-      summary: Verify OAuth/Third-Party OAuth Token
-      tags: [OAuth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AuthenticateOAuthRequest"
-      responses:
-        "200":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlayerResponse"
-        "401":
-          description: Unauthorized
-
-  # ============================
-  # Third-Party OAuth
-  # ============================
-  /iam/v1/oauth/link:
-    post:
-      summary: Link Third-Party OAuth
-      tags: [Third-Party OAuth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ThirdPartyLinkRequest"
-      responses:
-        "201":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthPlayerResponse"
-        "401":
-          description: Api key is not valid
-
-  /iam/v1/oauth/third_party:
-    post:
-      summary: Authenticate with Third-Party OAuth
-      tags: [Third-Party OAuth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ThirdPartyOAuthRequest"
-      responses:
-        "200":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthPlayerResponse"
-        "401":
-          description: Unauthorized
-
-  # =====================
-  # Basic Authentication
-  # =====================
-  /iam/v1/password/signup:
-    post:
-      summary: Email/Password Signup
-      tags: [Basic Auth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SignupRequest"
-      responses:
-        "201":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: "#/components/schemas/AuthResponse"
-                  - $ref: "#/components/schemas/ActionRequiredResponse"
-        "401":
-          description: Api key is not valid
-        "409":
-          description: User already exists
-
-  /iam/v1/password/login:
-    post:
-      summary: Email/Password Login
-      tags: [Basic Auth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LoginRequest"
-      responses:
-        "200":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: "#/components/schemas/AuthResponse"
-                  - $ref: "#/components/schemas/ActionRequiredResponse"
-        "401":
-          description: Unauthorized
-
-  /iam/v1/siwe/authenticate:
-    post:
-      summary: Wallet (SIWE) Authentication
-      tags: [Basic Auth]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SIWEAuthenticateRequest"
-      responses:
-        "200":
-          description: Success response
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AuthResponse"
-        "401":
-          description: Unauthorized
-
-# =====================
-# Shared Schemas
-# =====================
-components:
-  schemas:
-    OAuthInitRequest:
-      type: object
-      properties:
-        options:
-          type: object
-          properties:
-            redirectTo:
-              type: string
-            queryParams:
-              type: object
-              additionalProperties:
                 type: string
-            callbackTo:
-              type: string
-        usePooling:
-          type: boolean
-        provider:
-          type: string
-          enum: [google, twitter, facebook, discord, epic_games, line, apple]
-          example: google
-      required: [provider]
+              description: Space-separated list of allowed origins
+        "403":
+          description: Origin is not allowed
 
-    OAuthResponse:
-      type: object
-      properties:
-        key:
-          type: string
-          description: State key for OAuth session
-        url:
-          type: string
-          description: Authorization URL
+  # ==========================
+  # Health
+  # ==========================
+  /health:
+    get:
+      summary: Health check
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
 
-    LoginWithIdTokenRequest:
-      type: object
-      properties:
-        provider:
-          type: string
-          enum: [apple, google]
-          example: google
-        token:
-          type: string
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
-      required: [provider, token]
+# ==========================
+# Schemas
+# ==========================
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Session token passed as a Bearer token (enabled by the bearer plugin).
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: better-auth.session_token
+      description: Session cookie set by Better Auth.
 
-    AuthenticateOAuthRequest:
-      type: object
-      properties:
-        provider:
-          type: string
-          enum:
-            [
-              google,
-              twitter,
-              facebook,
-              discord,
-              epic_games,
-              line,
-              apple,
-              accelbyte,
-              firebase,
-              lootlocker,
-              playfab,
-              supabase,
-              custom,
-              oidc,
-            ]
-          example: google
-        token:
-          type: string
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
-        tokenType:
-          type: string
-          example: idToken
-        expand:
-          type: array
-          items:
-            type: string
-      required: [provider, token, tokenType]
-
-    ThirdPartyLinkRequest:
-      type: object
-      properties:
-        provider:
-          type: string
-          enum:
-            [accelbyte, firebase, lootlocker, playfab, supabase, custom, oidc]
-          example: firebase
-        token:
-          type: string
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
-        tokenType:
-          type: string
-          example: idToken
-      required: [provider, token, tokenType]
-
-    ThirdPartyOAuthRequest:
-      type: object
-      properties:
-        provider:
-          type: string
-          enum:
-            [accelbyte, firebase, lootlocker, playfab, supabase, custom, oidc]
-          example: firebase
-        token:
-          type: string
-          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
-        tokenType:
-          type: string
-          example: idToken
-      required: [provider, token, tokenType]
-
-    SignupRequest:
+  schemas:
+    SignUpRequest:
       type: object
       properties:
         email:
           type: string
-          example: user@email.com
+          format: email
+          example: user@example.com
         password:
           type: string
-          example: password
+          example: s3cur3P@ss
         name:
           type: string
-          example: John Doe
-        description:
+          example: Jane Doe
+        username:
           type: string
-          example: I'm a developer.
-      required: [email, password]
+          description: Optional username (max 30 characters, `admin` is blocked).
+          example: janedoe
+      required: [email, password, name]
 
-    LoginRequest:
+    SignInRequest:
       type: object
       properties:
         email:
           type: string
-          example: user@email.com
+          format: email
+          example: user@example.com
         password:
           type: string
-          example: password
+          example: s3cur3P@ss
       required: [email, password]
 
-    SIWEAuthenticateRequest:
+    SessionResponse:
       type: object
       properties:
-        signature:
-          type: string
-          example: 0x1773ca2e6514a795bc9549ffbdf73909b2cd0ba8eafe52a1751c3ee8d644458701debd502ee5b5a8fca24606eee42a2cc756a04958c7c189913184d46c48783e1b
-        message:
-          type: string
-          example: demo.openfort.xyz wants you to sign in with your Ethereum account
-        walletClientType:
-          type: string
-          example: metamask
-        connectorType:
-          type: string
-          example: injected
-      required: [signature, message, walletClientType, connectorType]
-
-    AuthResponse:
-      type: object
-      properties:
-        player:
-          $ref: "#/components/schemas/AuthPlayerResponse"
+        user:
+          $ref: "#/components/schemas/User"
+        session:
+          $ref: "#/components/schemas/Session"
         token:
           type: string
-          description: JWT access token
-        refreshToken:
-          type: string
-          description: Refresh token
+          description: Session token (present on sign-up and sign-in responses).
 
-    ActionRequiredResponse:
-      type: object
-      properties:
-        action:
-          type: string
-          enum: [verify_email]
-
-    AuthPlayerResponse:
+    User:
       type: object
       properties:
         id:
           type: string
-        name:
-          type: string
-        description:
-          type: string
-        metadata:
-          type: object
-        linkedAccounts:
-          type: array
-          items:
-            $ref: "#/components/schemas/LinkedAccountResponse"
-        player:
-          $ref: "#/components/schemas/PlayerResponse"
-
-    LinkedAccountResponse:
-      type: object
-      properties:
-        provider:
-          type: string
         email:
           type: string
-        externalUserId:
+        name:
           type: string
-        connectorType:
+        username:
           type: string
-        walletClientType:
-          type: string
-        disabled:
+        emailVerified:
           type: boolean
-        verified:
-          type: boolean
+        createdAt:
+          type: string
+          format: date-time
         updatedAt:
-          type: integer
-        address:
           type: string
-        metadata:
-          type: object
+          format: date-time
 
-    PlayerResponse:
+    Session:
       type: object
       properties:
         id:
           type: string
-        name:
+        userId:
           type: string
-        description:
+        expiresAt:
           type: string
-        metadata:
-          type: object
-        transactionIntents:
+          format: date-time
+        token:
+          type: string
+
+    JWKSResponse:
+      type: object
+      properties:
+        keys:
           type: array
           items:
             type: object
-        accounts:
-          type: array
-          items:
-            type: object
+            description: A JSON Web Key (JWK).


### PR DESCRIPTION
## Summary

- **Auth service swagger**: Rewrote `docs/public/swagger/auth_service.yaml` to document the actual Better Auth endpoints (`/api/auth/sign-up/email`, `/api/auth/sign-in/email`, `/api/auth/get-session`, `/api/auth/token`, `/api/auth/jwks`, etc.) instead of incorrect Openfort proprietary endpoints (`/iam/v1/oauth/*`, `/iam/v1/password/*`). Also documents the `/.well-known/jwks.json` alias, `/v1/projects/validate-origin`, and `/health` endpoints.
- **Broken anchor links**: Fixed `recovery-methods.mdx` links from `#user-with-password-recovery` → `#password-recovery` and `#user-with-automatic-recovery` → `#automatic-recovery` to match actual headings in `signup.mdx`.
- **At-rest encryption docs**: Added documentation about AES-256-GCM encryption via `SHARE_ENCRYPTION_KEY` to the hot storage component page, including implementation details and a key generation command.
- **Environment variables**: Replaced incorrect `env.example` reference in `setup.mdx` with a proper environment variables section documenting required (`JWT_SECRET`, `SHARE_ENCRYPTION_KEY`) and optional (`ALLOWED_ORIGINS`, `BETTER_AUTH_BASE_URL`, etc.) variables.
- **Malformed .env.example**: Fixed missing closing quotes in `auth_service/.env.example`.

## Test plan

- [ ] Verify swagger viewer renders correctly on the auth service API page
- [ ] Confirm anchor links in recovery-methods.mdx navigate to correct sections in signup.mdx
- [ ] Review hot storage encryption documentation for technical accuracy
- [ ] Verify setup page renders environment variable tables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)