### PR TITLE
docs: fix Vocs client hydration (search, Ask AI, theme toggle)

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,5 @@
 dist/
 src/pages.gen.ts
 public/diagrams/
+public/sitemap.xml
+public/robots.txt

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,6 +21,7 @@
     "@types/node": "^22.15.3",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
+    "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^5.8.3",
     "vite": "^8.0.0"
   }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.0
         version: 19.2.3(@types/react@19.2.10)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.14(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.2))
       typescript:
         specifier: ^5.8.3
         version: 5.9.3

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vocs/config'
 import { sidebar } from './sidebar'
 
 export default defineConfig({
-  baseUrl: 'https://opensigner.dev',
   title: 'OpenSigner | Non-Custodial Wallet Key Management',
   description: 'Open-source and non-custodial and self-hostable private key management.',
   logoUrl: {

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -1,6 +1,59 @@
+import NodeFS from 'node:fs'
+import NodePath from 'node:path'
+import Process from 'node:process'
 import { defineConfig } from 'vocs/config'
 
 import { sidebar } from './sidebar'
+
+const SITE_URL = 'https://opensigner.dev'
+
+// Generate sitemap.xml + robots.txt at build time. We intentionally do NOT set
+// the `baseUrl` config option: it injects <base href={SITE_URL}>, which makes
+// every relative asset (including the client bundle) resolve against the prod
+// domain and breaks hydration on any other origin (local preview, Vercel preview
+// deploys). Emitting these files directly keeps absolute SEO URLs without the tag.
+function collectRoutes(dir: string, prefix = ''): string[] {
+  const routes: string[] = []
+  for (const entry of NodeFS.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('_')) continue
+    const full = NodePath.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      routes.push(...collectRoutes(full, `${prefix}/${entry.name}`))
+      continue
+    }
+    if (!/\.(mdx|md|tsx)$/.test(entry.name)) continue
+    const base = entry.name.replace(/\.(mdx|md|tsx)$/, '')
+    const route = base === 'index' ? prefix || '/' : `${prefix}/${base}`
+    routes.push(route.replace(/\/{2,}/g, '/'))
+  }
+  return routes
+}
+
+function generateSeoFiles(): void {
+  const publicDir = NodePath.join(Process.cwd(), 'public')
+  const routes = collectRoutes(NodePath.join(Process.cwd(), 'src', 'pages')).sort()
+  const lastmod = new Date().toISOString().slice(0, 10)
+
+  const sitemap = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...routes.map((route) => {
+      const loc = route === '/' ? `${SITE_URL}/` : `${SITE_URL}${route}`
+      const priority = route === '/' ? '1.0' : '0.7'
+      return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <priority>${priority}</priority>\n  </url>`
+    }),
+    '</urlset>',
+    '',
+  ].join('\n')
+
+  const robots = ['User-agent: *', 'Allow: /', `Sitemap: ${SITE_URL}/sitemap.xml`, ''].join('\n')
+
+  NodeFS.mkdirSync(publicDir, { recursive: true })
+  NodeFS.writeFileSync(NodePath.join(publicDir, 'sitemap.xml'), sitemap)
+  NodeFS.writeFileSync(NodePath.join(publicDir, 'robots.txt'), robots)
+}
+
+generateSeoFiles()
 
 export default defineConfig({
   title: 'OpenSigner | Non-Custodial Wallet Key Management',


### PR DESCRIPTION
## Summary

After the Vocs 2.0 migration (#54), the docs site rendered but **never hydrated** — `Cmd+K` search, `Cmd+I` Ask AI, and the theme toggle were all inert.

Two compounding causes:

1. **`@vitejs/plugin-react` was missing.** The `vocs` CLI imports it to emit the client React bundle. Without it, the client entry was never shipped, so the page never hydrated. It's a required `devDependency` in the official `create-vocs` template.
2. **`baseUrl` injected `<base href="https://opensigner.dev">`**, which made every relative asset (including the client bundle) resolve against the production domain. On any other origin (local `vocs preview`, Vercel preview deploys) that's a CORS failure → client JS never loads. Removed it; assets now load from origin-relative `/assets/...` paths.

## SEO preserved
Dropping `baseUrl` would normally remove the auto-generated `sitemap.xml` / `robots.txt`. Instead, a small build-time generator in `vocs.config.ts` walks `src/pages` and writes both files to `public/` with absolute `opensigner.dev` URLs — without setting `baseUrl` (so no `<base>` tag). The stale tracked `robots.txt` is untracked; both files are now generated and gitignored.

## Verification (headless browser, production build via `vocs preview`)
- Home, `/introduction/about`, `/apis/auth_service`: **0 console errors, hydrated = true**
- Search dialog opens on click / `Cmd+K`
- Ask AI menu opens on click / `Cmd+I`
- Swagger API page renders 9 endpoints; d2 diagrams render
- `/sitemap.xml` (200, application/xml, 24 URLs) and `/robots.txt` (200) served

## Test plan
- [ ] Deploy preview: open any docs page, press `Cmd+K` → search opens
- [ ] Press `Cmd+I` → Ask AI menu opens
- [ ] Toggle light/dark theme
- [ ] `/sitemap.xml` and `/robots.txt` resolve
- [ ] No CORS / failed-resource errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)